### PR TITLE
Fix first template will always be loaded for tracker

### DIFF
--- a/scripts/issue_templates.js
+++ b/scripts/issue_templates.js
@@ -192,7 +192,7 @@ class ISSUE_TEMPLATE {
     dialog.style.visibility = 'visible';
     dialog.classList.add('active');
 
-    document.getElementById('overwrite_yes').addEventListener('click', () => {
+    document.getElementById('overwrite_yes').onclick = function(){
       if (document.getElementById('issue_template_confirm_to_replace_hide_dialog').checked) {
         // NOTE: Use document.cookie because Redmine itself does not use jquery.cookie.js.
         document.cookie = 'issue_template_confirm_to_replace_hide_dialog=1';
@@ -201,9 +201,9 @@ class ISSUE_TEMPLATE {
       }
       dialog.classList.remove('active');
       ns.replaceTemplateValue(obj);
-    });
+    };
 
-    document.getElementById('overwrite_no').addEventListener('click', () => {
+    document.getElementById('overwrite_no').onclick = function(){
       if (document.getElementById('issue_template_confirm_to_replace_hide_dialog').checked) {
         // NOTE: Use document.cookie because Redmine itself does not use jquery.cookie.js.
         document.cookie = 'issue_template_confirm_to_replace_hide_dialog=1';
@@ -211,12 +211,12 @@ class ISSUE_TEMPLATE {
         document.cookie = 'issue_template_confirm_to_replace_hide_dialog=0';
       }
       dialog.classList.remove('active');
-    });
+    };
 
     document.getElementById('issue_template_confirm_to_replace_dialog_cancel')
-      .addEventListener('click', () => {
+      .onclick = function(){
         dialog.classList.remove('active');
-      });
+      };
   }
   showLoadedMessage() {
     const ns = this;


### PR DESCRIPTION
Fix for issue #105.

If you change the template multiple times, on every change a new event listener is added, without removing the old ones.
This leads to the issue #105.